### PR TITLE
chore: enhance build workflow with schematic previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
-name: KiCAD CI with PDF Diff
+name: Build
 
 on:
   pull_request:
+    types: [opened, synchronize, closed]
     paths:
       - '**.kicad_sch'
       - '**.kicad_pcb'
@@ -19,6 +20,7 @@ on:
 jobs:
   build:
     name: Reports and PDF Diffs
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
@@ -70,6 +72,7 @@ jobs:
             for sch in $(find . -name '*.kicad_sch'); do
               outfile="reports/schematics/$(basename "$sch" .kicad_sch).pdf"
               kicad-cli sch export pdf "$sch" --output "$outfile"
+              pdftoppm "$outfile" "reports/schematics/$(basename "$sch" .kicad_sch)" -png -singlefile
             done
 
             echo "Generating PDFs for layouts ===============================>"
@@ -153,14 +156,84 @@ jobs:
           name: drc-report
           path: reports/drc-report.txt
 
-      - name: Upload schematic PDFs
+      - name: Upload schematics
         uses: actions/upload-artifact@v4
         with:
-          name: schematic-pdfs
-          path: reports/schematics/*.pdf
+          name: schematics
+          path: reports/schematics/*
 
       - name: Upload layout PDFs
         uses: actions/upload-artifact@v4
         with:
           name: layout-pdfs
           path: reports/layouts/*.pdf
+
+      - name: Set preview branch name
+        if: github.event_name == 'pull_request'
+        id: set-output
+        run: echo "branch=gh-preview-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
+      - name: Configure Git
+        if: github.event_name == 'pull_request'
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Push schematics to preview branch
+        if: github.event_name == 'pull_request'
+        run: |
+          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+          COMMIT_SHA_SHORT=${COMMIT_SHA:0:7}
+          BRANCH=gh-preview-${{ github.event.pull_request.number }}
+          git fetch origin
+          if git ls-remote --exit-code --heads origin "$BRANCH"; then
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout --orphan "$BRANCH"
+            git rm -rf .
+          fi
+          cp reports/schematics/*.png schematic-${COMMIT_SHA_SHORT}.png
+          git add schematic-${COMMIT_SHA_SHORT}.png
+          git commit -m "Add schematic preview for (${COMMIT_SHA_SHORT}) in PR${{ github.event.pull_request.number }}"
+          git push -f origin HEAD:$BRANCH
+
+
+  pr_comment:
+    name: Post PR Comment
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Comment on PR with image
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const imageUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/gh-preview-${prNumber}/schematic-${sha}.png`;
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**Schematic preview in commit ${sha}**:\n\n![schematic preview](${imageUrl})`
+            });
+
+  cleanup:
+    name: Cleanup
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Delete preview branch
+        run: |
+          BRANCH=gh-preview-${{ github.event.pull_request.number }}
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+          git fetch origin
+          git push origin --delete $BRANCH || echo "No preview branch to delete"
+
+


### PR DESCRIPTION
## Summary by Sourcery

Enhance the CI build workflow to generate schematic PNG previews, publish them to a per-PR preview branch, comment the PR with the preview image, and clean up the preview branch when the PR is closed.

New Features:
- Generate PNG previews for KiCAD schematics alongside the existing PDFs
- Push schematic preview images to a dedicated gh-preview-<PR> branch for each pull request
- Automatically post a comment on the PR with the inline schematic preview image
- Automatically delete the gh-preview branch when the pull request is closed

Enhancements:
- Rename the workflow to 'Build' and refine pull_request triggers to include opened, synchronize, and closed events
- Skip the build job when the pull_request action is 'closed'
- Include all schematic outputs (PDFs and PNGs) in the uploaded artifacts

CI:
- Configure Git in the CI job to commit and push preview branches
- Introduce separate 'pr_comment' and 'cleanup' jobs for posting preview comments and cleaning up branches