### PR TITLE
chore: minor tweaks for pr-comment

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "${{ github.event.number }}" > pr-number.txt
 
       - name: Expose commit SHA
-        run: echo "${{ github.sha }}" > commit-sha.txt
+        run: echo "${{ github.event.pull_request.head.sha }}" > commit-sha.txt
 
       - name: Upload PR ID
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -92,10 +92,9 @@ jobs:
             fi
           done
 
-          # Force push to schematic-previews branch
           git checkout --orphan temporary
           git add *.png
-          git commit -am "schematic previews for #${{ steps.fetch-pr-number.outputs.issue_number }}:${{ steps.fetch-pr-number.outputs.commit_sha }}"
+          git commit -am "schematic previews for PR${{ steps.fetch-pr-number.outputs.issue_number }}:${{ steps.fetch-pr-number.outputs.commit_sha }}"
           git branch -D schematic-previews
           git branch -m schematic-previews
           git push --force origin schematic-previews


### PR DESCRIPTION
## Summary by Sourcery

Standardize commit annotations and SHA resolution in GitHub Actions for PR previews and builds

CI:
- Prefix schematic preview commits with 'PR' instead of '#' in pr-preview workflow
- Use pull_request.head.sha for commit-sha.txt instead of github.sha in pr-build workflow