### PR TITLE
fix: duplicating directories

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: schematic-previews
-          path: schematic-previews
+          path: sch-previews
 
       - name: Clean schematic-previews branch
         run: |
@@ -49,12 +49,13 @@ jobs:
             fi
           done
           
-          cp schematic-previews/*.png . 2>/dev/null || true
+          find . -name "*.png" -exec mv -v '{}' . \; || true
+          rm -rf sch-previews
           git config user.name "actions-cleanup[bot]"
           git config user.email "actions-cleanup[bot]@users.noreply.github.com"
           git checkout --orphan temp-clean
           git rm -rf . > /dev/null 2>&1 || true
-          git add *.png 2>/dev/null || true
+          git add ./*.png 2>/dev/null || true
           git commit --allow-empty -m "Cleanup schematic previews" || echo "No changes"
           git branch -M schematic-previews
           git push -f origin schematic-previews
@@ -66,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: layout-previews
-          path: layout-previews
+          path: pcb-previews
 
       - name: Clean layout-previews branch
         run: |
@@ -89,12 +90,13 @@ jobs:
             fi
           done
 
-          cp layout-previews/*.png . 2>/dev/null || true
+          find . -name "*.png" -exec mv -v '{}' . \; || true
+          rm -rf pcb-previews
           git config user.name "actions-cleanup[bot]"
           git config user.email "actions-cleanup[bot]@users.noreply.github.com"
           git checkout --orphan temp-clean
           git rm -rf . > /dev/null 2>&1 || true
-          git add *.png 2>/dev/null || true
+          git add ./*.png 2>/dev/null || true
           git commit --allow-empty -m "Cleanup layout previews" || echo "No changes"
           git branch -M layout-previews
           git push -f origin layout-previews


### PR DESCRIPTION
## Summary by Sourcery

Revise the GitHub cleanup workflow to prevent duplicating preview directories by renaming checkout paths, consolidating assets via find/mv, and removing temporary directories before commit.

Bug Fixes:
- Fix duplicating preview directories during cleanup runs

Enhancements:
- Rename checkout paths for schematic and layout previews to sch-previews and pcb-previews
- Replace cp commands with find -exec mv to gather all PNGs into the repo root
- Add rm -rf steps to remove temporary preview directories after moving files
- Adjust git add patterns to explicitly include PNG files in the root