### PR TITLE
chore: build set to fail on ERC/DRC errors

### DIFF
--- a/.github/workflows/pr-build-layout.yml
+++ b/.github/workflows/pr-build-layout.yml
@@ -46,7 +46,7 @@ jobs:
           echo "uid=$(id -u)" >> $GITHUB_OUTPUT
           echo "gid=$(id -g)" >> $GITHUB_OUTPUT
 
-      - name: Run ERC, DRC, and generate PDFs
+      - name: Run DRC and generate PDFs
         uses: addnab/docker-run-action@v3
         with:
           image: cloudypadmal/pslab-mini-kicad:1.0.0
@@ -67,6 +67,7 @@ jobs:
               echo "=== DRC Report for $(basename "$pcb") ===" >> reports/drc-report.txt
               cat "$outfile" >> reports/drc-report.txt
               echo "" >> reports/drc-report.txt
+              rm -f "$outfile"
             done
             
             echo "Generating PDFs for layouts ===============================>"
@@ -150,3 +151,19 @@ jobs:
         with:
           name: layouts
           path: reports/layouts/*
+
+      - name: Build status from DRC report
+        run: |
+          violations=$(grep -oP 'Found [1-9][0-9]* DRC violations' reports/drc-report.txt | wc -l)
+          footprint_errors=$(grep -oP 'Found [1-9][0-9]* Footprint errors' reports/drc-report.txt | wc -l)
+          if [ "$violations" -ne 0 ]; then
+            echo "❌ DRC violations detected"
+            cat reports/drc-report.txt
+            exit 1
+          elif [ "$footprint_errors" -ne 0 ]; then
+            echo "❌ Footprint errors detected"
+            cat reports/drc-report.txt
+            exit 1
+          else
+            echo "✅ No DRC violations or footprint errors detected."
+          fi

--- a/.github/workflows/pr-build-schematic.yml
+++ b/.github/workflows/pr-build-schematic.yml
@@ -46,7 +46,7 @@ jobs:
           echo "uid=$(id -u)" >> $GITHUB_OUTPUT
           echo "gid=$(id -g)" >> $GITHUB_OUTPUT
 
-      - name: Run ERC, DRC, and generate PDFs
+      - name: Run ERC and generate PDFs
         uses: addnab/docker-run-action@v3
         with:
           image: cloudypadmal/pslab-mini-kicad:1.0.0
@@ -67,6 +67,7 @@ jobs:
               echo "=== ERC Report for $(basename "$sch") ===" >> reports/erc-report.txt
               cat "$outfile" >> reports/erc-report.txt
               echo "" >> reports/erc-report.txt
+              rm -f "$outfile"
             done
 
             echo "Generating PDFs for schematics ============================>"
@@ -113,3 +114,14 @@ jobs:
         with:
           name: schematics
           path: reports/schematics/*
+
+      - name: Build status from ERC report
+        run: |
+          errors=$(grep -oP 'Errors\s+\K[0-9]+' reports/erc-report.txt)
+          if [ "$errors" -ne 0 ]; then
+            echo "❌ ERC errors detected"
+            cat reports/erc-report.txt
+            exit 1
+          else
+            echo "✅ No ERC errors detected."
+          fi


### PR DESCRIPTION
## Summary by Sourcery

Enforce CI build failures on any ERC errors in schematics and DRC or footprint violations in layouts by parsing KiCad report outputs and updating workflows accordingly.

CI:
- Rename workflow steps to reflect the removed checks (ERC removed from layout, DRC removed from schematic)
- Clean up temporary report files after aggregation
- Add steps to parse DRC/footprint violations in layouts and ERC errors in schematics, failing the build on detection