### PR TITLE
Add security policy document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of the PSLab Mini Hardware project pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including GitHub issues, pull requests, discussions, and community channels such as [Gitter](https://gitter.im/fossasia/pslab).
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a private issue or contacting the FOSSASIA team via [pslab.io](https://pslab.io). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Scope
+
+This policy covers the PSLab Mini Hardware repository, including hardware design files, firmware references, and companion software components maintained in this repo.
+
+## Supported Versions
+
+The following versions receive security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest minor/patch | :white_check_mark: |
+| Older versions     | :x:                |
+
+## Reporting a Vulnerability
+
+1. **Do not open a public GitHub issue.**
+2. Open a **private security advisory** via the [GitHub Security tab](https://github.com/fossasia/pslab-mini-hardware/security/advisories/new).
+3. Include a description, reproduction steps, and potential impact.
+
+You can expect an initial response within **72 hours**.
+
+- **Accepted** → We work on a fix and credit you in release notes.
+- **Declined** → We provide a clear explanation.
+
+For general questions, use [Gitter](https://gitter.im/fossasia/pslab) or visit [pslab.io](https://pslab.io).


### PR DESCRIPTION
This document outlines the security policy for the PSLab Mini Hardware repository, including scope, supported versions, and vulnerability reporting procedures.

## Summary by Sourcery

Documentation:
- Introduce SECURITY.md documenting the project’s security policy, including scope, supported versions, and vulnerability reporting guidelines.